### PR TITLE
[MNT] Switch cd build to npm and node to v20

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -15,13 +15,13 @@ jobs:
     - name: Set up node env
       uses: actions/setup-node@v4.2.0
       with:
-        node-version: 18
+        node-version: 20
 
     - name: Install dependencies
-      run: yarn
+      run: npm ci
 
     - name: Generate
-      run: yarn generate
+      run: npm run generate
     
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v4


### PR DESCRIPTION
related to #866

<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #866 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- switched `cd` to use `npm ci` instead of `yarn`
- switched node version `v18` -> `v20`

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Migrate the continuous deployment build process to use npm instead of yarn and update the node version to v20.

Build:
- Switch from yarn to npm for dependency management and script execution.
- Update the node version to v20.